### PR TITLE
Feat/slack auth

### DIFF
--- a/src/interfaces/config.interface.ts
+++ b/src/interfaces/config.interface.ts
@@ -25,3 +25,5 @@ export interface ITiktokConfig extends BaseConfig {}
 export interface ILinkedinConfig extends BaseConfig {}
 export interface IRedditConfig extends BaseConfig {}
 export interface IGmailConfig extends BaseConfig {}
+export interface ISlackConfig extends BaseConfig {}
+ 

--- a/src/strategies/slack.strategy.ts
+++ b/src/strategies/slack.strategy.ts
@@ -1,0 +1,124 @@
+import axios from "axios";
+import { ISocialUser } from "../interfaces/social-user.interface";
+import { ISlackConfig } from "../interfaces/config.interface";
+import { SocialAuthResponse } from "../interfaces/easy-social-auth-response.interface";
+import { AuthStrategy } from "./easy-social-auth.strategy";
+
+export class SlackStrategy extends AuthStrategy {
+  private userId?: string;
+
+  constructor(config: ISlackConfig) {
+    super(
+      config.clientId,
+      config.clientSecret,
+      config.userInfoEndpoint,
+      config.tokenEndpoint,
+      config.authUrl
+    );
+  }
+
+  async exchangeCodeForToken(
+    code: string,
+    redirectUri: string
+  ): Promise<SocialAuthResponse<string>> {
+    try {
+      const params = new URLSearchParams();
+      params.append("client_id", this.clientId);
+      params.append("client_secret", this.clientSecret);
+      params.append("code", code);
+      params.append("redirect_uri", redirectUri);
+
+      const { data } = await axios.post(this.tokenEndpoint, params, {
+        headers: {
+          "Content-Type": "application/x-www-form-urlencoded",
+        },
+      });
+
+      if (!data || !data.ok) {
+        return {
+          status: false,
+          error: data?.error || "Slack OAuth error",
+        };
+      }
+
+      this.userId = data.authed_user?.id;
+      const accessToken =
+        data.authed_user?.access_token || data.access_token;
+
+      return {
+        status: true,
+        data: accessToken,
+      };
+    } catch (error: any) {
+      return {
+        status: false,
+        error: error.response?.data?.error || error.message,
+      };
+    }
+  }
+
+  async getUserData(
+    accessToken: string
+  ): Promise<SocialAuthResponse<ISocialUser>> {
+    try {
+      let userId = this.userId;
+
+      if (!userId) {
+        const authTestResp = await axios.post(
+          "https://slack.com/api/auth.test",
+          undefined,
+          {
+            headers: {
+              Authorization: `Bearer ${accessToken}`,
+            },
+          }
+        );
+        const authData = authTestResp.data;
+        if (!authData.ok) {
+          return {
+            status: false,
+            error: authData.error || "Failed to verify Slack token",
+          };
+        }
+        userId = authData.user_id;
+      }
+
+      const userResp = await axios.get(this.userInfoEndpoint, {
+        headers: {
+          Authorization: `Bearer ${accessToken}`,
+        },
+        params: { user: userId },
+      });
+
+      const userData = userResp.data;
+      if (!userData.ok) {
+        return {
+          status: false,
+          error: userData.error || "Failed to fetch Slack user info",
+        };
+      }
+
+      const user = userData.user;
+      const profile = user.profile || {};
+
+      const socialUser: ISocialUser = {
+        id: user.id,
+        email: profile.email,
+        firstName: profile.first_name,
+        lastName: profile.last_name,
+        picture: profile.image_512 || profile.image_192,
+        additionalData: userData,
+      };
+
+      return {
+        status: true,
+        data: socialUser,
+      };
+    } catch (error: any) {
+      return {
+        status: false,
+        error: error.response?.data?.error || error.message,
+      };
+    }
+  }
+}


### PR DESCRIPTION
This PR adds Slack OAuth integration to easy-social-auth.

- Introduces a new SlackStrategy class that implements Slack's OAuth v2 flow, exchanging authorization codes for access tokens via `https://slack.com/api/oauth.v2.access`, storing user ID and retrieving user info via `auth.test` and `users.info` endpoints.
- Adds `ISlackConfig` interface and extends the default config to include Slack-specific endpoints (authorization URL, token endpoint, user info endpoint, and revoke token URL).
- Exports the new SlackStrategy so developers can instantiate it directly with their Slack app credentials.

Using SlackStrategy allows obtaining Slack user and bot tokens and retrieving user details through the Slack API. This integration follows the existing structure for other providers in the library.

Future work: integrate SlackStrategy into SocialAuthService for automatic instantiation alongside other providers.